### PR TITLE
Detect inline schema from target file

### DIFF
--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -117,6 +117,37 @@ describe("CLI", function () {
       });
     });
 
+    it("should return 0 when file is valid (with inlined-detected schema)", function () {
+      const mock = nock("https://example.com")
+        .get("/specific-schema.json")
+        .reply(200, schema);
+
+      return cli({ filename: "./testfiles/inlined.yaml" }).then((result) => {
+        assert.equal(0, result);
+        expect(messages.log).to.contain("✅ ./testfiles/inlined.yaml is valid");
+        mock.done();
+      });
+    });
+
+    it("should return 99 when file is invalid (with inlined-detected schema)", function () {
+      const mock = nock("https://example.com")
+        .get("/wrong-schema.json")
+        .reply(200, {
+          type: "object",
+          properties: { num: { type: "object" } },
+        });
+
+      return cli({ filename: "./testfiles/invalid-inlined.yaml" }).then(
+        (result) => {
+          assert.equal(99, result);
+          expect(messages.log).to.contain(
+            "❌ ./testfiles/invalid-inlined.yaml is invalid"
+          );
+          mock.done();
+        }
+      );
+    });
+
     it("should find a schema using glob patterns", function () {
       const mock1 = nock("https://www.schemastore.org")
         .get("/api/json/catalog.json")

--- a/testfiles/inlined.yaml
+++ b/testfiles/inlined.yaml
@@ -1,0 +1,2 @@
+# v8r: $schema=https://example.com/specific-schema.json
+num: 4

--- a/testfiles/invalid-inlined.yaml
+++ b/testfiles/invalid-inlined.yaml
@@ -1,0 +1,2 @@
+# v8r: $schema=https://example.com/wrong-schema.json
+num: 4


### PR DESCRIPTION
I use megalinter to check all my project YAML files and like the v8r validation.

In my case, I've Ansible playbooks that are not detected as Ansible Playbooks because the `fileMatch` of the catalog matches `playbook.yml` and `playbook.yaml` (and an Ansible Playbook is never named `playbook`...)
Worst, two playbooks named `build.yml` and `deploy.yml` matches `fileMatch` of other schemas.

Linters usually allow you to declare specifics inline, at the top of a file.
This PR aims to meet this need using an inline-specified schema to prevent mismatches.

Should fix #61 as well.