### PR TITLE
--catalogs option feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ $ v8r feature.geojson
 $ v8r feature.geojson -s https://json.schemastore.org/geojson
 Validating feature.geojson against schema from https://json.schemastore.org/geojson ...
 ✅ feature.geojson is valid
+
+# ..or specify a custom catalog
+$ v8r feature.geojson -c my-catalog.json
+Validating feature.geojson against schema from https://json.schemastore.org/geojson ...
+✅ feature.geojson is valid
 ```
 
 ## Exit codes

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,8 +1,8 @@
 "use strict";
 
 const got = require("got");
-const callCounter = {};
 const callLimit = 10;
+let callCounter = {};
 
 function expire(cache, ttl) {
   Object.entries(cache.all()).forEach(function ([url, cachedResponse]) {
@@ -63,4 +63,8 @@ async function cachedFetch(url, cache, ttl) {
   }
 }
 
-module.exports = { cachedFetch, expire };
+function resetCallCounter() {
+  callCounter = {};
+}
+
+module.exports = { cachedFetch, expire, resetCallCounter };

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,7 @@ const SCHEMASTORE_CATALOG_URL =
   "https://www.schemastore.org/api/json/catalog.json";
 
 const SCHEMASTORE_CATALOG_SCHEMA_URL =
-  "https://www.schemastore.org/api/json/schema-catalog.json";
+  "https://json.schemastore.org/schema-catalog.json";
 
 const CACHE_DIR = path.join(os.tmpdir(), "flat-cache");
 
@@ -44,7 +44,7 @@ async function getSchemaUrlForFilename(catalogs, filename, cache, ttl) {
     const { schemas } = catalog;
     const matches = getSchemaMatchesForFilename(schemas, filename);
     if (matches.length === 1) {
-      console.log(`ℹ️ Found schema in ${catalog} ...`);
+      console.log(`ℹ️ Found schema in ${catalogLocation} ...`);
       return matches[0].url; // Match found. We're done.
     }
     if (matches.length === 0 && i < catalogs.length - 1) {
@@ -211,7 +211,7 @@ function parseArgs(argv) {
       alias: "c",
       array: true,
       describe:
-        "Local paths of custom catalogs to use prior to schemastore.org",
+        "Local path or URL of custom catalogs to use prior to schemastore.org",
     })
     .conflicts("schema", "catalogs")
     .option("ignore-errors", {

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -9,8 +9,9 @@ const { setUp, tearDown } = require("./test-helpers.js");
 chai.use(require("chai-as-promised"));
 
 describe("CLI", function () {
-  // Moch the catalog validation schema
+  // Mock the catalog validation schema
   beforeEach(() => {
+    nock.disableNetConnect();
     nock("https://json.schemastore.org")
       .persist()
       .get("/schema-catalog.json")
@@ -149,7 +150,7 @@ describe("CLI", function () {
       });
     });
 
-    it("should return 0 when file is valid (with auto-detected schema from custom local catalog matching remote schema)", function () {
+    it("should return 0 when file is valid (with auto-detected schema from custom local catalog)", function () {
       const storeMock = nock("https://www.schemastore.org")
         .get("/api/json/catalog.json")
         .reply(200, {
@@ -175,7 +176,7 @@ describe("CLI", function () {
       });
     });
 
-    it("should return 0 when file is valid (with auto-detected schema from custom remote catalog matching remote schema)", function () {
+    it("should return 0 when file is valid (with auto-detected schema from custom remote catalog)", function () {
       const catalogMock = nock("https://my-catalog.com")
         .get("/catalog.json")
         .reply(200, {
@@ -229,7 +230,7 @@ describe("CLI", function () {
       });
     });
 
-    it("should return 0 when file is valid (with auto-detected schema from custom catalog fallbacking to the next catalog)", function () {
+    it("should return 0 when file is valid (with auto-detected schema from custom catalog falling back to the next catalog)", function () {
       const mock = nock("https://example.com")
         .get("/schema.json")
         .reply(200, schema);
@@ -247,7 +248,7 @@ describe("CLI", function () {
       });
     });
 
-    it("should return 0 when file is valid (with auto-detected schema from custom catalog fallbacking to schemastore.org)", function () {
+    it("should return 0 when file is valid (with auto-detected schema from custom catalog falling back to schemastore.org)", function () {
       const storeMock = nock("https://www.schemastore.org")
         .get("/api/json/catalog.json")
         .reply(200, {
@@ -497,7 +498,7 @@ describe("CLI", function () {
         assert.equal(1, result);
         mock.done();
         expect(messages.error).to.contain(
-          "❌ Malformed catalog at https://example.com/catalog.json",
+          "❌ Malformed catalog at https://example.com/catalog.json"
         );
       });
     });

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -22,7 +22,6 @@ describe("CLI", function () {
       return cli({
         filename: "./testfiles/valid.json",
         schema: "./testfiles/schema.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(0, result);
         expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
@@ -33,7 +32,6 @@ describe("CLI", function () {
       return cli({
         filename: "./testfiles/invalid.json",
         schema: "./testfiles/schema.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(99, result);
         expect(messages.log).to.contain(
@@ -50,7 +48,6 @@ describe("CLI", function () {
       return cli({
         filename: "./testfiles/valid.json",
         schema: "https://example.com/schema.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(0, result);
         expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
@@ -66,7 +63,6 @@ describe("CLI", function () {
       return cli({
         filename: "./testfiles/invalid.json",
         schema: "https://example.com/schema.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(99, result);
         expect(messages.log).to.contain(
@@ -93,60 +89,8 @@ describe("CLI", function () {
 
       return cli({
         filename: "./testfiles/valid.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(0, result);
-        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
-        mock1.done();
-        mock2.done();
-      });
-    });
-
-    it("should return 0 when file is valid (with auto-detected schema from custom catalog matching local schema)", function () {
-      return cli({
-        filename: "./testfiles/valid.json",
-        catalogs: ["./testfiles/catalog-local.json"],
-      }).then((result) => {
-        assert.equal(0, result);
-        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
-      });
-    });
-
-    it("should return 0 when file is valid (with auto-detected schema from custom catalog matching schema URL)", function () {
-      const mock = nock("https://example.com")
-        .get("/schema.json")
-        .reply(200, schema);
-
-      return cli({
-        filename: "./testfiles/valid.json",
-        catalogs: ["./testfiles/catalog-url.json"],
-      }).then((result) => {
-        assert.equal(0, result, messages.error);
-        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
-        mock.done();
-      });
-    });
-
-    it("should return 0 when file is valid (with auto-detected schema from custom catalog fallbacking to schemastore.org)", function () {
-      const mock1 = nock("https://www.schemastore.org")
-        .get("/api/json/catalog.json")
-        .reply(200, {
-          schemas: [
-            {
-              url: "https://example.com/schema.json",
-              fileMatch: ["valid.json", "invalid.json"],
-            },
-          ],
-        });
-      const mock2 = nock("https://example.com")
-        .get("/schema.json")
-        .reply(200, schema);
-
-      return cli({
-        filename: "./testfiles/valid.json",
-        catalogs: ["./testfiles/catalog-nomatch.json"],
-      }).then((result) => {
-        assert.equal(0, result, messages.error);
         expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
         mock1.done();
         mock2.done();
@@ -170,7 +114,6 @@ describe("CLI", function () {
 
       return cli({
         filename: "./testfiles/invalid.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(99, result);
         expect(messages.log).to.contain(
@@ -178,6 +121,157 @@ describe("CLI", function () {
         );
         mock1.done();
         mock2.done();
+      });
+    });
+
+    it("should return 0 when file is valid (with auto-detected schema from custom local catalog matching local schema)", function () {
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["./testfiles/catalog-local.json"],
+      }).then((result) => {
+        assert.equal(0, result);
+        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
+      });
+    });
+
+    it("should return 0 when file is valid (with auto-detected schema from custom local catalog matching remote schema)", function () {
+      const storeMock = nock("https://www.schemastore.org")
+        .get("/api/json/catalog.json")
+        .reply(200, {
+          schemas: [
+            {
+              url: "https://example.com/not-used-schema.json",
+              fileMatch: ["valid.json", "invalid.json"],
+            },
+          ],
+        });
+      const catalogSchemaMock = nock("https://example.com")
+        .get("/schema.json")
+        .reply(200, schema);
+
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["./testfiles/catalog-url.json"],
+      }).then((result) => {
+        assert.equal(0, result, messages.error);
+        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
+        expect(storeMock.isDone()).to.be.false;
+        catalogSchemaMock.done();
+      });
+    });
+
+    it("should return 0 when file is valid (with auto-detected schema from custom remote catalog matching remote schema)", function () {
+      const catalogMock = nock("https://my-catalog.com")
+        .get("/catalog.json")
+        .reply(200, {
+          schemas: [
+            {
+              url: "https://example.com/schema.json",
+              fileMatch: ["valid.json", "invalid.json"],
+            },
+          ],
+        });
+      const catalogSchemaMock = nock("https://example.com")
+        .get("/schema.json")
+        .reply(200, schema);
+
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["https://my-catalog.com/catalog.json"],
+      }).then((result) => {
+        assert.equal(0, result, messages.error);
+        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
+        catalogMock.done();
+        catalogSchemaMock.done();
+      });
+    });
+
+    it("should return 0 when file is valid (with auto-detected schema from custom remote catalog matching relativly defined schema)", function () {
+      const catalogMock = nock("https://my-catalog.com")
+        .get("/catalog.json")
+        .reply(200, {
+          schemas: [
+            {
+              url: "testfiles/schema.json",
+              fileMatch: ["valid.json", "invalid.json"],
+            },
+          ],
+        });
+
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["https://my-catalog.com/catalog.json"],
+      }).then((result) => {
+        assert.equal(0, result, messages.error);
+        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
+        catalogMock.done();
+      });
+    });
+
+    it("should return 99 when file is invalid (with auto-detected schema and custom catalogs)", function () {
+      const mock1 = nock("https://www.schemastore.org")
+        .get("/api/json/catalog.json")
+        .reply(200, {
+          schemas: [
+            {
+              url: "https://example.com/schema.json",
+              fileMatch: ["valid.json", "invalid.json"],
+            },
+          ],
+        });
+      const mock2 = nock("https://example.com")
+        .get("/schema.json")
+        .reply(200, schema);
+
+      return cli({
+        filename: "./testfiles/invalid.json",
+        catalogs: ["./testfiles/catalog-nomatch.json"],
+      }).then((result) => {
+        assert.equal(99, result, messages.error);
+        expect(messages.log).to.contain(
+          "❌ ./testfiles/invalid.json is invalid"
+        );
+        mock1.done();
+        mock2.done();
+      });
+    });
+
+    it("should return 0 when file is valid (with auto-detected schema from custom catalog fallbacking to the next catalog)", function () {
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: [
+          "./testfiles/catalog-nomatch.json",
+          "./testfiles/catalog-local.json",
+        ],
+      }).then((result) => {
+        assert.equal(0, result, messages.error);
+        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
+      });
+    });
+
+    it("should return 0 when file is valid (with auto-detected schema from custom catalog fallbacking to schemastore.org)", function () {
+      const storeMock = nock("https://www.schemastore.org")
+        .get("/api/json/catalog.json")
+        .reply(200, {
+          schemas: [
+            {
+              url: "https://example.com/schema.json",
+              fileMatch: ["valid.json", "invalid.json"],
+            },
+          ],
+        });
+      const storeSchemaMock = nock("https://example.com")
+        .get("/schema.json")
+        .reply(200, schema);
+
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["./testfiles/catalog-nomatch.json"],
+      }).then((result) => {
+        assert.equal(0, result, messages.error);
+        expect(messages.log).to.contain("✅ ./testfiles/valid.json is valid");
+        storeMock.done();
+        storeSchemaMock.done();
       });
     });
 
@@ -209,7 +303,6 @@ describe("CLI", function () {
       return cli({
         filename: "./testfiles/valid.yaml",
         schema: "./testfiles/schema.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(0, result);
         expect(messages.log).to.contain("✅ ./testfiles/valid.yaml is valid");
@@ -334,7 +427,6 @@ describe("CLI", function () {
       return cli({
         filename: "./testfiles/valid.json",
         schema: "https://example.com/schema.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(1, result);
         expect(messages.error[0]).to.contain(
@@ -347,7 +439,6 @@ describe("CLI", function () {
     it("should return 1 if local target file not found", async function () {
       return cli({
         filename: "./testfiles/does-not-exist.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(1, result);
         expect(messages.error).to.contain(
@@ -359,7 +450,6 @@ describe("CLI", function () {
     it("should return 1 if target file type is not supported", async function () {
       return cli({
         filename: "./testfiles/not-supported.txt",
-        catalogs: [],
       }).then((result) => {
         assert.equal(1, result);
         expect(messages.error).to.contain("❌ Unsupported format .txt");
@@ -370,7 +460,6 @@ describe("CLI", function () {
       return cli({
         filename: "./testfiles/valid.json",
         schema: "./testfiles/does-not-exist.json",
-        catalogs: [],
       }).then((result) => {
         assert.equal(1, result);
         expect(messages.error).to.contain(
@@ -386,7 +475,79 @@ describe("CLI", function () {
       }).then((result) => {
         assert.equal(1, result);
         expect(messages.error).to.contain(
-          "❌ Catalog not found: ./testfiles/does-not-exist.json"
+          "ENOENT: no such file or directory, open './testfiles/does-not-exist.json'"
+        );
+      });
+    });
+
+    it("should return 1 if invalid response fetching remote catalog", async function () {
+      const mock = nock("https://example.com")
+        .get("/catalog.json")
+        .reply(404, {});
+
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["https://example.com/catalog.json"],
+      }).then((result) => {
+        assert.equal(1, result);
+        expect(messages.error[0]).to.contain(
+          "❌ Failed fetching https://example.com/catalog.json"
+        );
+        mock.done();
+      });
+    });
+
+    it("should return 1 on malformed catalog (missing 'schemas')", async function () {
+      const mock = nock("https://example.com")
+        .get("/catalog.json")
+        .reply(200, {});
+
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["https://example.com/catalog.json"],
+      }).then((result) => {
+        assert.equal(1, result);
+        mock.done();
+        expect(messages.error).to.contain(
+          "❌ Malformed catalog at https://example.com/catalog.json"
+        );
+      });
+    });
+
+    it("should return 1 on malformed catalog ('schemas' should be an array)", async function () {
+      const mock = nock("https://example.com")
+        .get("/catalog.json")
+        .reply(200, { schemas: {} });
+
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["https://example.com/catalog.json"],
+      }).then((result) => {
+        assert.equal(1, result);
+        mock.done();
+        expect(messages.error).to.contain(
+          "❌ Malformed catalog at https://example.com/catalog.json"
+        );
+      });
+    });
+
+    it("should return 1 on malformed catalog ('schemas' elements should contains an url)", async function () {
+      const mock = nock("https://example.com")
+        .get("/catalog.json")
+        .reply(200, {
+          schemas: {
+            name: "Missing url schema",
+          },
+        });
+
+      return cli({
+        filename: "./testfiles/valid.json",
+        catalogs: ["https://example.com/catalog.json"],
+      }).then((result) => {
+        assert.equal(1, result);
+        mock.done();
+        expect(messages.error).to.contain(
+          "❌ Malformed catalog at https://example.com/catalog.json"
         );
       });
     });
@@ -395,7 +556,6 @@ describe("CLI", function () {
       return cli({
         filename: "./testfiles/not-supported.txt",
         ignoreErrors: true,
-        catalogs: [],
       }).then((result) => {
         assert.equal(0, result);
         expect(messages.error).to.contain("❌ Unsupported format .txt");
@@ -410,7 +570,7 @@ describe("Argument parser", function () {
     expect(args).to.have.property("ignoreErrors", false);
     expect(args).to.have.property("cacheTtl", 600);
     expect(args).to.have.property("verbose", 0);
-    expect(args).to.have.property("catalogs").that.eql([]);
+    expect(args).to.not.have.property("catalogs");
     expect(args).to.not.have.property("schema");
   });
 

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -290,13 +290,11 @@ describe("CLI", function () {
         .get("/schema.json")
         .reply(200, schema);
 
-      return cli({ filename: "./testfiles/valid.json", catalogs: [] }).then(
-        (result) => {
-          assert.equal(0, result);
-          mock1.done();
-          mock2.done();
-        }
-      );
+      return cli({ filename: "./testfiles/valid.json" }).then((result) => {
+        assert.equal(0, result);
+        mock1.done();
+        mock2.done();
+      });
     });
 
     it("should validate yaml files", function () {
@@ -320,15 +318,13 @@ describe("CLI", function () {
         .get("/api/json/catalog.json")
         .reply(404, {});
 
-      return cli({ filename: "./testfiles/valid.json", catalogs: [] }).then(
-        (result) => {
-          assert.equal(1, result);
-          expect(messages.error[0]).to.contain(
-            "❌ Failed fetching https://www.schemastore.org/api/json/catalog.json"
-          );
-          mock.done();
-        }
-      );
+      return cli({ filename: "./testfiles/valid.json" }).then((result) => {
+        assert.equal(1, result);
+        expect(messages.error[0]).to.contain(
+          "❌ Failed fetching https://www.schemastore.org/api/json/catalog.json"
+        );
+        mock.done();
+      });
     });
 
     it("should return 1 if invalid response fetching auto-detected schema", async function () {
@@ -346,16 +342,14 @@ describe("CLI", function () {
         .get("/schema.json")
         .reply(404, {});
 
-      return cli({ filename: "./testfiles/valid.json", catalogs: [] }).then(
-        (result) => {
-          assert.equal(1, result);
-          expect(messages.error[0]).to.contain(
-            "❌ Failed fetching https://example.com/schema.json"
-          );
-          mock1.done();
-          mock2.done();
-        }
-      );
+      return cli({ filename: "./testfiles/valid.json" }).then((result) => {
+        assert.equal(1, result);
+        expect(messages.error[0]).to.contain(
+          "❌ Failed fetching https://example.com/schema.json"
+        );
+        mock1.done();
+        mock2.done();
+      });
     });
 
     it("should return 1 if we can't find a schema", async function () {
@@ -370,15 +364,13 @@ describe("CLI", function () {
           ],
         });
 
-      return cli({ filename: "./testfiles/valid.json", catalogs: [] }).then(
-        (result) => {
-          assert.equal(1, result);
-          expect(messages.error).to.contain(
-            "❌ Could not find a schema to validate ./testfiles/valid.json"
-          );
-          mock.done();
-        }
-      );
+      return cli({ filename: "./testfiles/valid.json" }).then((result) => {
+        assert.equal(1, result);
+        expect(messages.error).to.contain(
+          "❌ Could not find a schema to validate ./testfiles/valid.json"
+        );
+        mock.done();
+      });
     });
 
     it("should return 1 if multiple schemas are matched", async function () {
@@ -399,24 +391,22 @@ describe("CLI", function () {
           ],
         });
 
-      return cli({ filename: "./testfiles/valid.json", catalogs: [] }).then(
-        (result) => {
-          assert.equal(1, result);
-          expect(messages.error).to.contain(
-            "❌ Could not find a schema to validate ./testfiles/valid.json"
-          );
-          expect(messages.log).to.contain(
-            "Found multiple possible schemas for ./testfiles/valid.json. Possible matches:"
-          );
-          expect(messages.log).to.contain(
-            "example schema 1: https://example.com/schema1.json"
-          );
-          expect(messages.log).to.contain(
-            "example schema 2: https://example.com/schema2.json"
-          );
-          mock.done();
-        }
-      );
+      return cli({ filename: "./testfiles/valid.json" }).then((result) => {
+        assert.equal(1, result);
+        expect(messages.error).to.contain(
+          "❌ Could not find a schema to validate ./testfiles/valid.json"
+        );
+        expect(messages.log).to.contain(
+          "Found multiple possible schemas for ./testfiles/valid.json. Possible matches:"
+        );
+        expect(messages.log).to.contain(
+          "example schema 1: https://example.com/schema1.json"
+        );
+        expect(messages.log).to.contain(
+          "example schema 2: https://example.com/schema2.json"
+        );
+        mock.done();
+      });
     });
 
     it("should return 1 if invalid response fetching user-supplied schema", async function () {

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -202,34 +202,6 @@ describe("CLI", function () {
       });
     });
 
-    it("should return 99 when file is invalid (with auto-detected schema and custom catalogs)", function () {
-      const mock1 = nock("https://www.schemastore.org")
-        .get("/api/json/catalog.json")
-        .reply(200, {
-          schemas: [
-            {
-              url: "https://example.com/schema.json",
-              fileMatch: ["valid.json", "invalid.json"],
-            },
-          ],
-        });
-      const mock2 = nock("https://example.com")
-        .get("/schema.json")
-        .reply(200, schema);
-
-      return cli({
-        filename: "./testfiles/invalid.json",
-        catalogs: ["./testfiles/catalog-nomatch.json"],
-      }).then((result) => {
-        assert.equal(99, result, messages.error);
-        expect(messages.log).to.contain(
-          "❌ ./testfiles/invalid.json is invalid"
-        );
-        mock1.done();
-        mock2.done();
-      });
-    });
-
     it("should return 0 when file is valid (with auto-detected schema from custom catalog falling back to the next catalog)", function () {
       const mock = nock("https://example.com")
         .get("/schema.json")

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const flatCache = require("flat-cache");
+const cache = require("./cache.js");
 
 const originals = {};
 const consoleMethods = ["log", "error", "debug"];
@@ -16,6 +17,7 @@ function setUp(messages) {
 }
 
 function tearDown() {
+  cache.resetCallCounter();
   flatCache.clearCacheById(testCacheName);
   consoleMethods.forEach(function (fn) {
     console[fn] = originals[fn];

--- a/testfiles/catalog-local.json
+++ b/testfiles/catalog-local.json
@@ -1,0 +1,13 @@
+{
+  "version": 1.0,
+  "schemas": [
+    {
+      "name": "Valid custom schema",
+      "fileMatch": [
+        "valid.json",
+        "valid.yml"
+      ],
+      "url": "./schema.json"
+    }
+  ]
+}

--- a/testfiles/catalog-local.json
+++ b/testfiles/catalog-local.json
@@ -7,7 +7,7 @@
         "valid.json",
         "valid.yml"
       ],
-      "url": "./schema.json"
+      "url": "testfiles/schema.json"
     }
   ]
 }

--- a/testfiles/catalog-local.json
+++ b/testfiles/catalog-local.json
@@ -1,8 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/schema-catalog.json",
   "version": 1.0,
   "schemas": [
     {
       "name": "Valid custom schema",
+      "description": "",
       "fileMatch": [
         "valid.json",
         "valid.yml"

--- a/testfiles/catalog-nomatch.json
+++ b/testfiles/catalog-nomatch.json
@@ -1,0 +1,4 @@
+{
+  "version": 1.0,
+  "schemas": []
+}

--- a/testfiles/catalog-url.json
+++ b/testfiles/catalog-url.json
@@ -1,0 +1,13 @@
+{
+  "version": 1.0,
+  "schemas": [
+    {
+      "name": "Valid custom schema",
+      "fileMatch": [
+        "valid.json",
+        "valid.yml"
+      ],
+      "url": "https://example.com/schema.json"
+    }
+  ]
+}

--- a/testfiles/catalog-url.json
+++ b/testfiles/catalog-url.json
@@ -1,8 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/schema-catalog.json",
   "version": 1.0,
   "schemas": [
     {
       "name": "Valid custom schema",
+      "description": "",
       "fileMatch": [
         "valid.json",
         "valid.yml"


### PR DESCRIPTION
Add a new --catalogs option to specify custom catalogs to find schemas prior to the default schemas store.

The initial PR #87 were trying to manage custom schemas when running across multiple files by introducing inline comment in YAML files. As discussed in [this PR](https://github.com/chris48s/v8r/pull/87#issuecomment-877775254). Introducing a `catalogs` option is more accurate to implements a solution for both YAML and JSON files.

Should fix #17 and #61