### PR TITLE
Fix --version option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix --version option
+
 ## 📦 [0.10.0](https://www.npmjs.com/package/v8r/v/0.10.0) - 2022-01-03
 
 * Accept multiple filenames or globs as positional args. e.g:

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@ import flatCache from "flat-cache";
 import fs from "fs";
 import isUrl from "is-url";
 import minimatch from "minimatch";
+import { createRequire } from "module";
 import os from "os";
 import path from "path";
 import yargs from "yargs";
@@ -199,13 +200,7 @@ function parseArgs(argv) {
         });
       }
     )
-    .version(
-      // Workaround for https://github.com/yargs/yargs/issues/1934
-      // TODO: remove once fixed
-      JSON.parse(
-        fs.readFileSync(new URL("../package.json", import.meta.url).pathname)
-      ).version
-    )
+    .version(createRequire(import.meta.url)("../package.json").version)
     .option("verbose", {
       alias: "v",
       type: "boolean",


### PR DESCRIPTION
v8r --vesion was crashing on windows and on alpine linux

Before fix:

```
$ v8r --version
(node:26404) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/C:/Users/33614/AppData/Roaming/npm/node_modules/v8r/package.json'
    at Object.openSync (fs.js:498:3)
    at Object.readFileSync (fs.js:394:35)
    at parseArgs (file:///C:/Users/33614/AppData/Roaming/npm/node_modules/v8r/src/cli.js:206:12)
    at file:///C:/Users/33614/AppData/Roaming/npm/node_modules/v8r/src/index.js:6:30
    at file:///C:/Users/33614/AppData/Roaming/npm/node_modules/v8r/src/index.js:8:3
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:177:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
```

After fix:

```
$ v8r --version
0.10.0
```