### PR TITLE
add toml to list of allowed parsers in `customCatalog`s

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -53,8 +53,9 @@
                 "type": "string",
                 "enum": [
                   "json",
-                  "yaml",
-                  "json5"
+                  "json5",
+                  "toml",
+                  "yaml"
                 ]
               }
             }


### PR DESCRIPTION
fix