### PR TITLE
plugin interface: internals

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -5,6 +5,7 @@
   ],
   "exclude": [
     "**/*.spec.js",
-    "src/test-helpers.js"
+    "src/test-helpers.js",
+    "testfiles/plugins/**"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ export GLOBAL_AGENT_HTTP_PROXY=http://myproxy:8888
 * v8r always exits with code `97` when:
     * There was an error loading a config file
     * A config file was loaded but failed validation
-    * An error was encountered when loading plugins
+    * There was an error loading a plugin
+    * A plugin file was loaded but failed validation
 
 * v8r always exits with code `98` when:
     * An input glob pattern was invalid

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ export GLOBAL_AGENT_HTTP_PROXY=http://myproxy:8888
 * v8r always exits with code `97` when:
     * There was an error loading a config file
     * A config file was loaded but failed validation
+    * An error was encountered when loading plugins
 
 * v8r always exits with code `98` when:
     * An input glob pattern was invalid

--- a/config-schema.json
+++ b/config-schema.json
@@ -50,12 +50,7 @@
               },
               "parser": {
                 "description": "A custom parser to use for files matching fileMatch instead of trying to infer the correct parser from the filename",
-                "type": "string",
-                "enum": [
-                  "json",
-                  "yaml",
-                  "json5"
-                ]
+                "type": "string"
               }
             }
           }
@@ -64,11 +59,7 @@
     },
     "format": {
       "description": "Output format for validation results",
-      "type": "string",
-      "enum": [
-        "text",
-        "json"
-      ]
+      "type": "string"
     },
     "ignoreErrors": {
       "description": "Exit with code 0 even if an error was encountered. True means a non-zero exit code is only issued if validation could be completed successfully and one or more files were invalid",

--- a/config-schema.json
+++ b/config-schema.json
@@ -49,7 +49,7 @@
                 "type": "string"
               },
               "parser": {
-                "description": "A custom parser to use for files matching fileMatch instead of trying to infer the correct parser from the filename",
+                "description": "A custom parser to use for files matching fileMatch instead of trying to infer the correct parser from the filename. 'json', 'json5', 'toml' and 'yaml' are always valid. Plugins may define additional values which are valid here.",
                 "type": "string"
               }
             }
@@ -58,7 +58,7 @@
       }
     },
     "format": {
-      "description": "Output format for validation results",
+      "description": "Output format for validation results. 'text' and 'json' are always valid. Plugins may define additional values which are valid here.",
       "type": "string"
     },
     "ignoreErrors": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "bin": {
     "v8r": "src/index.js"
   },
-  "main": "src/index.js",
-  "exports": "./src/index.js",
+  "exports": "./src/public.js",
   "files": [
     "src/**/!(*.spec).js",
     "config-schema.json",

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -185,7 +185,7 @@ async function bootstrap(argv, config, cosmiconfigOptions = {}) {
     };
   }
 
-  // load the configfile and validate it against the schema
+  // load the config file and validate it against the schema
   const configFile = await getCosmiConfig(cosmiconfigOptions);
   validateConfigAgainstSchema(configFile);
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -121,7 +121,7 @@ function Validator() {
       results[filename] = await validateFile(filename, config, plugins, cache);
 
       for (const plugin of plugins) {
-        const message = plugin.logSingleResult(
+        const message = plugin.getSingleResultLogMessage(
           results[filename],
           filename,
           config.format,
@@ -136,7 +136,7 @@ function Validator() {
     }
 
     for (const plugin of plugins) {
-      const message = plugin.logAllResults(results, config.format);
+      const message = plugin.getAllResultsLogMessage(results, config.format);
       if (message != null) {
         logger.log(message);
         break;

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -766,7 +766,7 @@ describe("CLI", function () {
         schema: "./testfiles/schemas/schema.json",
       }).then((result) => {
         assert.equal(result, 1);
-        assert(logContainsError("Unsupported format .txt"));
+        assert(logContainsError("Unsupported format txt"));
       });
     });
 
@@ -874,7 +874,7 @@ describe("CLI", function () {
         ignoreErrors: true,
       }).then((result) => {
         assert.equal(result, 0);
-        assert(logContainsError("Unsupported format .txt"));
+        assert(logContainsError("Unsupported format txt"));
       });
     });
 
@@ -939,7 +939,7 @@ describe("CLI", function () {
         assert.equal(result, 99);
         assert(logContainsSuccess("./testfiles/files/valid.json is valid"));
         assert(logContainsError("./testfiles/files/invalid.json is invalid"));
-        assert(logContainsError("Unsupported format .txt"));
+        assert(logContainsError("Unsupported format txt"));
       });
     });
 
@@ -952,7 +952,7 @@ describe("CLI", function () {
       }).then((result) => {
         assert.equal(result, 1);
         assert(logContainsSuccess("./testfiles/files/valid.json is valid"));
-        assert(logContainsError("Unsupported format .txt"));
+        assert(logContainsError("Unsupported format txt"));
       });
     });
 
@@ -966,7 +966,7 @@ describe("CLI", function () {
       }).then((result) => {
         assert.equal(result, 0);
         assert(logContainsSuccess("./testfiles/files/valid.json is valid"));
-        assert(logContainsError("Unsupported format .txt"));
+        assert(logContainsError("Unsupported format txt"));
       });
     });
   });
@@ -990,7 +990,7 @@ describe("CLI", function () {
       }).then(() => {
         assert(
           logger.stdout.includes(
-            "./testfiles/files/invalid.json#/num must be number",
+            "./testfiles/files/invalid.json#/num must be number\n",
           ),
         );
       });

--- a/src/config-validators.js
+++ b/src/config-validators.js
@@ -1,0 +1,54 @@
+import { createRequire } from "module";
+// TODO: once JSON modules is stable these requires could become imports
+// https://nodejs.org/api/esm.html#esm_experimental_json_modules
+const require = createRequire(import.meta.url);
+
+import Ajv2019 from "ajv/dist/2019.js";
+import logger from "./logger.js";
+import { formatErrors } from "./output-formatters.js";
+
+function validateConfigAgainstSchema(configFile) {
+  const ajv = new Ajv2019({ allErrors: true, strict: false });
+  const schema = require("../config-schema.json");
+  const validateFn = ajv.compile(schema);
+  const valid = validateFn(configFile.config);
+  if (!valid) {
+    logger.log(
+      formatErrors(
+        configFile.filepath ? configFile.filepath : "",
+        validateFn.errors,
+      ),
+    );
+    throw new Error("Malformed config file");
+  }
+  return true;
+}
+
+function validateConfigDocumentParsers(configFile, documentFormats) {
+  for (const schema of configFile.config?.customCatalog?.schemas || []) {
+    if (schema?.parser != null && !documentFormats.includes(schema?.parser)) {
+      throw new Error(
+        `Malformed config file: "${schema.parser}" not in ${JSON.stringify(documentFormats)}`,
+      );
+    }
+  }
+  return true;
+}
+
+function validateConfigOutputFormats(configFile, outputFormats) {
+  if (
+    configFile.config?.format != null &&
+    !outputFormats.includes(configFile.config?.format)
+  ) {
+    throw new Error(
+      `Malformed config file: "${configFile.config.format}" not in ${JSON.stringify(outputFormats)}`,
+    );
+  }
+  return true;
+}
+
+export {
+  validateConfigAgainstSchema,
+  validateConfigDocumentParsers,
+  validateConfigOutputFormats,
+};

--- a/src/config-validators.spec.js
+++ b/src/config-validators.spec.js
@@ -1,0 +1,167 @@
+import assert from "assert";
+
+import { getDocumentFormats, getOutputFormats } from "./bootstrap.js";
+import {
+  validateConfigAgainstSchema,
+  validateConfigDocumentParsers,
+  validateConfigOutputFormats,
+} from "./config-validators.js";
+import { loadAllPlugins } from "./plugins.js";
+import { setUp, tearDown } from "./test-helpers.js";
+
+const validConfigs = [
+  { config: {} },
+  {
+    config: {
+      ignoreErrors: true,
+      verbose: 0,
+      patterns: ["foobar.js"],
+      cacheTtl: 600,
+      format: "json",
+      customCatalog: {
+        schemas: [
+          {
+            name: "Schema 1",
+            fileMatch: ["file1.json"],
+            location: "localschema.json",
+          },
+          {
+            name: "Schema 2",
+            description: "Long Description",
+            fileMatch: ["file2.json"],
+            location: "https://example.com/remoteschema.json",
+            parser: "json5",
+          },
+        ],
+      },
+    },
+  },
+];
+
+const { allLoadedPlugins } = await loadAllPlugins([]);
+const documentFormats = getDocumentFormats(allLoadedPlugins);
+const outputFormats = getOutputFormats(allLoadedPlugins);
+
+describe("validateConfigAgainstSchema", function () {
+  const messages = {};
+
+  beforeEach(function () {
+    setUp(messages);
+  });
+
+  afterEach(function () {
+    tearDown();
+  });
+
+  it("should pass valid configs", function () {
+    for (const config of validConfigs) {
+      assert(validateConfigAgainstSchema(config));
+    }
+  });
+
+  it("should reject invalid configs", function () {
+    const invalidConfigs = [
+      { config: { ignoreErrors: "string" } },
+      { config: { foo: "bar" } },
+      { config: { verbose: "string" } },
+      { config: { verbose: -1 } },
+      { config: { patterns: "string" } },
+      { config: { patterns: [] } },
+      { config: { patterns: ["valid", "ok", false] } },
+      { config: { patterns: ["duplicate", "duplicate"] } },
+      { config: { cacheTtl: "string" } },
+      { config: { cacheTtl: -1 } },
+      { config: { customCatalog: "string" } },
+      { config: { customCatalog: {} } },
+      { config: { customCatalog: { schemas: [{}] } } },
+      {
+        config: {
+          customCatalog: {
+            schemas: [
+              {
+                name: "Schema 1",
+                fileMatch: ["file1.json"],
+                location: "localschema.json",
+                foo: "bar",
+              },
+            ],
+          },
+        },
+      },
+      {
+        config: {
+          customCatalog: {
+            schemas: [
+              {
+                name: "Schema 1",
+                fileMatch: ["file1.json"],
+                location: "localschema.json",
+                url: "https://example.com/remoteschema.json",
+              },
+            ],
+          },
+        },
+      },
+    ];
+    for (const config of invalidConfigs) {
+      assert.throws(() => validateConfigAgainstSchema(config), {
+        name: "Error",
+        message: "Malformed config file",
+      });
+    }
+  });
+});
+
+describe("validateConfigDocumentParsers", function () {
+  it("should pass valid configs", function () {
+    for (const config of validConfigs) {
+      assert(validateConfigDocumentParsers(config, documentFormats));
+    }
+  });
+
+  it("should reject invalid configs", function () {
+    const invalidConfigs = [
+      {
+        config: {
+          customCatalog: {
+            schemas: [
+              {
+                name: "Schema 1",
+                fileMatch: ["file1.json"],
+                location: "localschema.json",
+                parser: "invalid",
+              },
+            ],
+          },
+        },
+      },
+    ];
+    for (const config of invalidConfigs) {
+      assert.throws(
+        () => validateConfigDocumentParsers(config, documentFormats),
+        {
+          name: "Error",
+          message: /^Malformed config file.*$/,
+        },
+      );
+    }
+  });
+});
+
+describe("validateConfigOutputFormats", function () {
+  it("should pass valid configs", function () {
+    for (const config of validConfigs) {
+      assert(validateConfigOutputFormats(config, outputFormats));
+    }
+  });
+
+  it("should reject invalid configs", function () {
+    const invalidConfigs = [{ config: { format: "invalid" } }];
+    for (const config of invalidConfigs) {
+      assert.throws(() => validateConfigOutputFormats(config, outputFormats), {
+        name: "Error",
+        message: /^Malformed config file.*$/,
+      });
+    }
+  });
+});

--- a/src/output-formatters.js
+++ b/src/output-formatters.js
@@ -1,19 +1,13 @@
 import Ajv from "ajv";
-import logger from "./logger.js";
 
-function logErrors(filename, errors) {
+function formatErrors(filename, errors) {
   const ajv = new Ajv();
-  logger.log(
+  return (
     ajv.errorsText(errors, {
       separator: "\n",
       dataVar: filename + "#",
-    }),
+    }) + "\n"
   );
-  logger.log("");
 }
 
-function resultsToJson(results) {
-  logger.log(JSON.stringify({ results }, null, 2));
-}
-
-export { logErrors, resultsToJson };
+export { formatErrors };

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,24 +1,18 @@
-import JSON5 from "json5";
+import path from "path";
 import yaml from "js-yaml";
-import { parse } from "smol-toml";
 
-function parseDocument(contents, format) {
-  switch (format) {
-    case ".json":
-    case ".geojson":
-    case ".jsonld":
-      return JSON.parse(contents);
-    case ".jsonc":
-    case ".json5":
-      return JSON5.parse(contents);
-    case ".yml":
-    case ".yaml":
-      return yaml.load(contents);
-    case ".toml":
-      return parse(contents);
-    default:
-      throw new Error(`Unsupported format ${format}`);
+function parseDocument(plugins, contents, filename, format) {
+  for (const plugin of plugins) {
+    const result = plugin.parseDocument(contents, filename, format);
+    if (result != null) {
+      return result;
+    }
   }
+
+  const errorMessage = format
+    ? `Unsupported format ${format}`
+    : `Unsupported format ${path.extname(filename).slice(1)}`;
+  throw new Error(errorMessage);
 }
 
 function parseSchema(contents, location) {

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,0 +1,87 @@
+class BasePlugin {
+  static name = "untitled plugin";
+
+  registerDocumentFormats() {
+    return [];
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  parseDocument(contents, filename, format) {
+    return undefined;
+  }
+
+  registerOutputFormats() {
+    return [];
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  logSingleResult(result, filename, format) {
+    return undefined;
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  logAllResults(results, format) {
+    return undefined;
+  }
+}
+
+function validatePlugin(plugin) {
+  if (
+    typeof plugin.name !== "string" ||
+    !plugin.name.startsWith("v8r-plugin-")
+  ) {
+    throw new Error(`Plugin ${plugin.name} does not declare a valid name`);
+  }
+
+  if (!(plugin.prototype instanceof BasePlugin)) {
+    throw new Error(`Plugin ${plugin.name} does not extend BasePlugin`);
+  }
+
+  for (const prop of Object.getOwnPropertyNames(BasePlugin.prototype)) {
+    const method = plugin.prototype[prop];
+    const argCount = plugin.prototype[prop].length;
+    if (typeof method !== "function") {
+      throw new Error(
+        `Error loading plugin ${plugin.name}: must have a method called ${method}`,
+      );
+    }
+    if (BasePlugin.prototype[prop].length !== argCount) {
+      throw new Error(
+        `Error loading plugin ${plugin.name}: ${prop} must take exactly ${argCount} arguments`,
+      );
+    }
+  }
+}
+
+async function loadPlugins(plugins) {
+  let loadedPlugins = [];
+  for (const plugin of plugins) {
+    loadedPlugins.push(await import(plugin));
+  }
+  loadedPlugins = loadedPlugins.map((plugin) => plugin.default);
+  loadedPlugins.forEach((plugin) => validatePlugin(plugin));
+  loadedPlugins = loadedPlugins.map((plugin) => new plugin());
+  return loadedPlugins;
+}
+
+async function loadAllPlugins(userPlugins) {
+  const loadedUserPlugins = await loadPlugins(userPlugins);
+
+  const corePlugins = [
+    "./plugins/parser-json.js",
+    "./plugins/parser-json5.js",
+    "./plugins/parser-toml.js",
+    "./plugins/parser-yaml.js",
+    "./plugins/output-text.js",
+    "./plugins/output-json.js",
+  ];
+  const loadedCorePlugins = await loadPlugins(corePlugins);
+
+  return {
+    allLoadedPlugins: loadedUserPlugins.concat(loadedCorePlugins),
+    loadedCorePlugins,
+    loadedUserPlugins,
+  };
+}
+
+export { BasePlugin, loadAllPlugins };

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -15,12 +15,12 @@ class BasePlugin {
   }
 
   // eslint-disable-next-line no-unused-vars
-  logSingleResult(result, filename, format) {
+  getSingleResultLogMessage(result, filename, format) {
     return undefined;
   }
 
   // eslint-disable-next-line no-unused-vars
-  logAllResults(results, format) {
+  getAllResultsLogMessage(results, format) {
     return undefined;
   }
 }

--- a/src/plugins.spec.js
+++ b/src/plugins.spec.js
@@ -1,0 +1,67 @@
+import assert from "assert";
+import { loadAllPlugins } from "./plugins.js";
+
+describe("loadAllPlugins", function () {
+  it("should load the core plugins", async function () {
+    const plugins = await loadAllPlugins([]);
+    assert.equal(plugins.allLoadedPlugins.length, 6);
+    assert.equal(plugins.loadedCorePlugins.length, 6);
+    assert.equal(plugins.loadedUserPlugins.length, 0);
+  });
+
+  it("should load valid user plugins", async function () {
+    const plugins = await loadAllPlugins(["../testfiles/plugins/valid.js"]);
+    assert.equal(plugins.allLoadedPlugins.length, 7);
+    assert.equal(plugins.loadedCorePlugins.length, 6);
+    assert.equal(plugins.loadedUserPlugins.length, 1);
+  });
+
+  it("should fail loading local plugin that does not exist", async function () {
+    await assert.rejects(
+      loadAllPlugins(["../testfiles/plugins/does-not-exist.js"]),
+      {
+        name: "Error",
+        message: /^Cannot find module.*$/,
+      },
+    );
+  });
+
+  it("should fail loading package plugin that does not exist", async function () {
+    await assert.rejects(loadAllPlugins(["does-not-exist"]), {
+      name: "Error",
+      message: /^Cannot find package.*$/,
+    });
+  });
+
+  it("should reject plugin with invalid name", async function () {
+    await assert.rejects(
+      loadAllPlugins(["../testfiles/plugins/invalid-name.js"]),
+      {
+        name: "Error",
+        message: "Plugin bad-plugin-name does not declare a valid name",
+      },
+    );
+  });
+
+  it("should reject plugin that does not extend BasePlugin", async function () {
+    await assert.rejects(
+      loadAllPlugins(["../testfiles/plugins/invalid-base.js"]),
+      {
+        name: "Error",
+        message:
+          "Plugin v8r-plugin-test-invalid-base does not extend BasePlugin",
+      },
+    );
+  });
+
+  it("should reject plugin with invalid parameters", async function () {
+    await assert.rejects(
+      loadAllPlugins(["../testfiles/plugins/invalid-params.js"]),
+      {
+        name: "Error",
+        message:
+          "Error loading plugin v8r-plugin-test-invalid-params: registerDocumentFormats must take exactly 1 arguments",
+      },
+    );
+  });
+});

--- a/src/plugins/output-json.js
+++ b/src/plugins/output-json.js
@@ -7,7 +7,7 @@ class JsonOutput extends BasePlugin {
     return ["json"];
   }
 
-  logAllResults(results, format) {
+  getAllResultsLogMessage(results, format) {
     if (format === "json") {
       return JSON.stringify({ results }, null, 2);
     }

--- a/src/plugins/output-json.js
+++ b/src/plugins/output-json.js
@@ -1,0 +1,17 @@
+import { BasePlugin } from "../plugins.js";
+
+class JsonOutput extends BasePlugin {
+  static name = "v8r-plugin-json-output";
+
+  registerOutputFormats() {
+    return ["json"];
+  }
+
+  logAllResults(results, format) {
+    if (format === "json") {
+      return JSON.stringify({ results }, null, 2);
+    }
+  }
+}
+
+export default JsonOutput;

--- a/src/plugins/output-text.js
+++ b/src/plugins/output-text.js
@@ -1,0 +1,18 @@
+import { BasePlugin } from "../plugins.js";
+import { formatErrors } from "../output-formatters.js";
+
+class TextOutput extends BasePlugin {
+  static name = "v8r-plugin-text-output";
+
+  registerOutputFormats() {
+    return ["text"];
+  }
+
+  logSingleResult(result, filename, format) {
+    if (result.valid === false && format === "text") {
+      return formatErrors(filename, result.errors);
+    }
+  }
+}
+
+export default TextOutput;

--- a/src/plugins/output-text.js
+++ b/src/plugins/output-text.js
@@ -8,7 +8,7 @@ class TextOutput extends BasePlugin {
     return ["text"];
   }
 
-  logSingleResult(result, filename, format) {
+  getSingleResultLogMessage(result, filename, format) {
     if (result.valid === false && format === "text") {
       return formatErrors(filename, result.errors);
     }

--- a/src/plugins/parser-json.js
+++ b/src/plugins/parser-json.js
@@ -1,0 +1,25 @@
+import { BasePlugin } from "../plugins.js";
+
+class JsonParser extends BasePlugin {
+  static name = "v8r-plugin-json-parser";
+
+  registerDocumentFormats() {
+    return ["json"];
+  }
+
+  parseDocument(contents, filename, format) {
+    if (format === "json") {
+      return JSON.parse(contents);
+    } else if (format == null) {
+      if (
+        filename.endsWith(".json") ||
+        filename.endsWith(".geojson") ||
+        filename.endsWith(".jsonld")
+      ) {
+        return JSON.parse(contents);
+      }
+    }
+  }
+}
+
+export default JsonParser;

--- a/src/plugins/parser-json5.js
+++ b/src/plugins/parser-json5.js
@@ -1,0 +1,22 @@
+import JSON5 from "json5";
+import { BasePlugin } from "../plugins.js";
+
+class Json5Parser extends BasePlugin {
+  static name = "v8r-plugin-json5-parser";
+
+  registerDocumentFormats() {
+    return ["json5"];
+  }
+
+  parseDocument(contents, filename, format) {
+    if (format === "json5") {
+      return JSON5.parse(contents);
+    } else if (format == null) {
+      if (filename.endsWith(".json5") || filename.endsWith(".jsonc")) {
+        return JSON5.parse(contents);
+      }
+    }
+  }
+}
+
+export default Json5Parser;

--- a/src/plugins/parser-toml.js
+++ b/src/plugins/parser-toml.js
@@ -1,0 +1,22 @@
+import { parse } from "smol-toml";
+import { BasePlugin } from "../plugins.js";
+
+class TomlParser extends BasePlugin {
+  static name = "v8r-plugin-toml-parser";
+
+  registerDocumentFormats() {
+    return ["toml"];
+  }
+
+  parseDocument(contents, filename, format) {
+    if (format === "toml") {
+      return parse(contents);
+    } else if (format == null) {
+      if (filename.endsWith(".toml")) {
+        return parse(contents);
+      }
+    }
+  }
+}
+
+export default TomlParser;

--- a/src/plugins/parser-yaml.js
+++ b/src/plugins/parser-yaml.js
@@ -1,0 +1,22 @@
+import yaml from "js-yaml";
+import { BasePlugin } from "../plugins.js";
+
+class YamlParser extends BasePlugin {
+  static name = "v8r-plugin-yaml-parser";
+
+  registerDocumentFormats() {
+    return ["yaml"];
+  }
+
+  parseDocument(contents, filename, format) {
+    if (format === "yaml") {
+      return yaml.load(contents);
+    } else if (format == null) {
+      if (filename.endsWith(".yaml") || filename.endsWith(".yml")) {
+        return yaml.load(contents);
+      }
+    }
+  }
+}
+
+export default YamlParser;

--- a/src/public.js
+++ b/src/public.js
@@ -1,0 +1,3 @@
+import { BasePlugin } from "./plugins.js";
+
+export { BasePlugin };

--- a/testfiles/plugins/invalid-base.js
+++ b/testfiles/plugins/invalid-base.js
@@ -1,0 +1,3 @@
+export default class InvalidBaseTestPlugin {
+  static name = "v8r-plugin-test-invalid-base";
+}

--- a/testfiles/plugins/invalid-name.js
+++ b/testfiles/plugins/invalid-name.js
@@ -1,0 +1,5 @@
+import { BasePlugin } from "v8r";
+
+export default class InvalidNameTestPlugin extends BasePlugin {
+  static name = "bad-plugin-name";
+}

--- a/testfiles/plugins/invalid-params.js
+++ b/testfiles/plugins/invalid-params.js
@@ -1,0 +1,10 @@
+import { BasePlugin } from "v8r";
+
+export default class InvalidParamsTestPlugin extends BasePlugin {
+  static name = "v8r-plugin-test-invalid-params";
+
+  // eslint-disable-next-line no-unused-vars
+  registerDocumentFormats(foo) {
+    return [];
+  }
+}

--- a/testfiles/plugins/valid.js
+++ b/testfiles/plugins/valid.js
@@ -1,0 +1,5 @@
+import { BasePlugin } from "v8r";
+
+export default class ValidTestPlugin extends BasePlugin {
+  static name = "v8r-plugin-test-valid";
+}


### PR DESCRIPTION
Initial go at a plugin interface. More work to do here..

Next steps:

- Extend config file format to allow user to specify `userPlugins`
- ~Do you want to allow loading plugins using command line args, or is this config file only Data point: ESLint does allow loading plugins and rules on the command line. Could have a `--plugins` (plural to match `--catalogs`) array param.~ https://github.com/chris48s/v8r/pull/477#discussion_r1698937178
- More plugin hooks: ~What else do you need? Probably do output formatters next..~
- ~Dogfood it: Try implementing more internal functionality as plugins as you define more hooks~
- ~Edit package.json to make the main export BasePlugin~
- ~Spike implementing other stuff as plugins~ https://github.com/chris48s/v8r/pull/477#issuecomment-2256614508
- Test loading plugins from outside the repo installed as NPM package
- Other TODO comments
- Documentation
    - Interface + plugin tutorial
    - Semver compatibility (what other internal do you need to expose? Might be useful to allow plugins to access some internals like the logger module, for example)
- Tests explicitly covering plugin functionality

I reckon you can probably merge a lot of this as just changes to internals before you expose/document it as an end user facing feature.