### PR TITLE
de-dupe and sort array of filenames

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -113,6 +113,10 @@ function Validator() {
       filenames = filenames.concat(matches);
     }
 
+    // de-dupe and sort
+    filenames = [...new Set(filenames)];
+    filenames.sort((a, b) => a.localeCompare(b));
+
     const ttl = secondsToMilliseconds(config.cacheTtl || 0);
     const cache = new Cache(getFlatCache(), ttl);
 

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -969,6 +969,24 @@ describe("CLI", function () {
         assert(logContainsError("Unsupported format txt"));
       });
     });
+
+    it("should de-duplicate and sort paths", async function () {
+      return cli({
+        patterns: [
+          "./testfiles/files/valid.json",
+          "./testfiles/files/valid.json",
+          "./testfiles/files/invalid.json",
+        ],
+        schema: "./testfiles/schemas/schema.json",
+        format: "json",
+      }).then(() => {
+        const json = JSON.parse(logger.stdout[0]);
+        const results = json.results;
+        assert.equal(results.length, 2);
+        assert.equal(results[0].fileLocation, "./testfiles/files/invalid.json");
+        assert.equal(results[1].fileLocation, "./testfiles/files/valid.json");
+      });
+    });
   });
 
   describe("output formats", function () {

--- a/src/glob.js
+++ b/src/glob.js
@@ -3,9 +3,7 @@ import logger from "./logger.js";
 
 async function getFiles(pattern) {
   try {
-    let matches = await glob(pattern, { dot: true, dotRelative: true });
-    matches.sort((a, b) => a.localeCompare(b));
-    return matches;
+    return await glob(pattern, { dot: true, dotRelative: true });
   } catch (e) {
     logger.error(e.message);
     return [];


### PR DESCRIPTION
In v3, making filename the object key ensured we didn't process the same file twice.
Now this is an array, we need to explicitly de-duplicate.