### PR TITLE
allow parsing multi-doc yaml files

### DIFF
--- a/docs/docs/usage-examples.md
+++ b/docs/docs/usage-examples.md
@@ -28,10 +28,12 @@ By default, v8r queries [Schema Store](https://www.schemastore.org/) to detect a
 ```bash
 # if v8r can't auto-detect a schema for your file..
 $ v8r feature.geojson
+ℹ Processing ./feature.geojson
 ✖ Could not find a schema to validate feature.geojson
 
 # ..you can specify one using the --schema flag
 $ v8r feature.geojson --schema https://json.schemastore.org/geojson
+ℹ Processing ./feature.geojson
 ℹ Validating feature.geojson against schema from https://json.schemastore.org/geojson ...
 ✔ feature.geojson is valid
 ```
@@ -50,11 +52,29 @@ Using the `--schema` flag will validate all files matched by the glob pattern ag
                  "fileMatch": ["*.geojson"] } ] }
 ```
 
-```bash
+```
 $ v8r feature.geojson -c my-catalog.json
+ℹ Processing ./feature.geojson
 ℹ Found schema in my-catalog.json ...
 ℹ Validating feature.geojson against schema from https://json.schemastore.org/geojson ...
 ✔ feature.geojson is valid
 ```
 
 This can be used to specify different custom schemas for multiple file patterns.
+
+## Files Containing Multiple Documents
+
+A single YAML file can contain [multiple documents](https://www.yaml.info/learn/document.html). v8r is able to parse and validate these files. In this situation:
+
+- All documents within the file are assumed to conform to the same schema. It is not possible to validate documents within the same file against different schemas
+- Documents within the file are referred to as `multi-doc.yml[0]`, `multi-doc.yml[1]`, etc
+
+```
+$ v8r catalog-info.yaml
+ℹ Processing ./catalog-info.yaml
+ℹ Found schema in https://www.schemastore.org/api/json/catalog.json ...
+ℹ Validating ./catalog-info.yaml against schema from https://json.schemastore.org/catalog-info.json ...
+✔ ./catalog-info.yaml[0] is valid
+
+✔ ./catalog-info.yaml[1] is valid
+```

--- a/src/output-formatters.js
+++ b/src/output-formatters.js
@@ -1,13 +1,20 @@
 import Ajv from "ajv";
 
-function formatErrors(filename, errors) {
+function getDocumentLocation(result) {
+  if (result.documentIndex == null) {
+    return result.fileLocation;
+  }
+  return `${result.fileLocation}[${result.documentIndex}]`;
+}
+
+function formatErrors(location, errors) {
   const ajv = new Ajv();
   return (
     ajv.errorsText(errors, {
       separator: "\n",
-      dataVar: filename + "#",
+      dataVar: location + "#",
     }) + "\n"
   );
 }
 
-export { formatErrors };
+export { formatErrors, getDocumentLocation };

--- a/src/parser.js
+++ b/src/parser.js
@@ -4,14 +4,20 @@ import { Document } from "./plugins.js";
 
 function parseFile(plugins, contents, filename, parser) {
   for (const plugin of plugins) {
-    const result = plugin.parseInputFile(contents, filename, parser);
-    if (result != null) {
-      if (!(result instanceof Document)) {
-        throw new Error(
-          `Plugin ${plugin.constructor.name} returned an unexpected type from parseInputFile hook. Expected Document, got ${typeof result}`,
-        );
+    const parsedFile = plugin.parseInputFile(contents, filename, parser);
+
+    if (parsedFile != null) {
+      const maybeDocuments = Array.isArray(parsedFile)
+        ? parsedFile
+        : [parsedFile];
+      for (const doc of maybeDocuments) {
+        if (!(doc instanceof Document)) {
+          throw new Error(
+            `Plugin ${plugin.constructor.name} returned an unexpected type from parseInputFile hook. Expected Document, got ${typeof doc}`,
+          );
+        }
       }
-      return result.document;
+      return maybeDocuments.map((md) => md.document);
     }
   }
 

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -32,7 +32,8 @@ class BasePlugin {
    * If `parseInputFile` returns anything other than undefined, that return
    * value will be used and no further plugins will be invoked. If
    * `parseInputFile` returns undefined, v8r will move on to the next plugin in
-   * the stack.
+   * the stack. The result of successfully parsing a file can either be a single
+   * Document object or an array of Document objects.
    *
    * @param {string} contents - The unparsed file content.
    * @param {string} fileLocation - The file path. Filenames are resolved and
@@ -43,7 +44,7 @@ class BasePlugin {
    * @param {string | undefined} parser - If the user has specified a parser to
    *   use for this file in a custom schema, this will be passed to
    *   `parseInputFile` in the `parser` param.
-   * @returns {Document | undefined} Parsed file contents
+   * @returns {Document | Document[] | undefined} Parsed file contents
    */
   // eslint-disable-next-line no-unused-vars
   parseInputFile(contents, fileLocation, parser) {
@@ -205,6 +206,12 @@ async function loadAllPlugins(userPlugins) {
  *   This means relative paths in the current directory will be prefixed with
  *   `./` (or `.\` on Windows) even if this was not present in the input
  *   filename or pattern.
+ * @property {number | null} documentIndex - Some file formats allow multiple
+ *   documents to be embedded in one file (e.g:
+ *   [yaml](https://www.yaml.info/learn/document.html)). In these cases,
+ *   `documentIndex` identifies is used to identify the sub document within the
+ *   file. `documentIndex` will be `null` when there is a one-to-one
+ *   relationship between file and document.
  * @property {string | null} schemaLocation - Location of the schema used to
  *   validate this file if one could be found. `null` if no schema was found.
  * @property {boolean | null} valid - Result of the validation (true/false) if a

--- a/src/plugins.spec.js
+++ b/src/plugins.spec.js
@@ -86,9 +86,9 @@ describe("resolveUserPlugins", function () {
 });
 
 describe("parseInputFile", function () {
-  it("throws when parseInputFile returns unexpected type", async function () {
+  it("throws when parseInputFile returns unexpected object", async function () {
     const plugins = await loadAllPlugins([
-      "../testfiles/plugins/bad-parse-method.js",
+      "../testfiles/plugins/bad-parse-method1.js",
     ]);
     assert.throws(
       () => parseFile(plugins.allLoadedPlugins, "{}", "foo.json", null),
@@ -96,6 +96,20 @@ describe("parseInputFile", function () {
         name: "Error",
         message:
           "Plugin v8r-plugin-test-bad-parse-method returned an unexpected type from parseInputFile hook. Expected Document, got object",
+      },
+    );
+  });
+
+  it("throws when parseInputFile returns unexpected array", async function () {
+    const plugins = await loadAllPlugins([
+      "../testfiles/plugins/bad-parse-method2.js",
+    ]);
+    assert.throws(
+      () => parseFile(plugins.allLoadedPlugins, "{}", "foo.json", null),
+      {
+        name: "Error",
+        message:
+          "Plugin v8r-plugin-test-bad-parse-method returned an unexpected type from parseInputFile hook. Expected Document, got string",
       },
     );
   });

--- a/src/plugins/output-text.js
+++ b/src/plugins/output-text.js
@@ -1,5 +1,5 @@
 import { BasePlugin } from "../plugins.js";
-import { formatErrors } from "../output-formatters.js";
+import { formatErrors, getDocumentLocation } from "../output-formatters.js";
 
 class TextOutput extends BasePlugin {
   static name = "v8r-plugin-text-output";
@@ -10,7 +10,7 @@ class TextOutput extends BasePlugin {
 
   getSingleResultLogMessage(result, fileLocation, format) {
     if (result.valid === false && format === "text") {
-      return formatErrors(fileLocation, result.errors);
+      return formatErrors(getDocumentLocation(result), result.errors);
     }
   }
 }

--- a/src/plugins/parser-yaml.js
+++ b/src/plugins/parser-yaml.js
@@ -10,10 +10,10 @@ class YamlParser extends BasePlugin {
 
   parseInputFile(contents, fileLocation, parser) {
     if (parser === "yaml") {
-      return new Document(yaml.load(contents));
+      return yaml.loadAll(contents).map((doc) => new Document(doc));
     } else if (parser == null) {
       if (fileLocation.endsWith(".yaml") || fileLocation.endsWith(".yml")) {
-        return new Document(yaml.load(contents));
+        return yaml.loadAll(contents).map((doc) => new Document(doc));
       }
     }
   }

--- a/testfiles/files/multi-doc.yaml
+++ b/testfiles/files/multi-doc.yaml
@@ -1,0 +1,9 @@
+---
+num: 4
+---
+num: 200
+---
+num: foo
+
+# this yaml file contains 3 documents
+# the first two are valid, the third is not

--- a/testfiles/plugins/bad-parse-method1.js
+++ b/testfiles/plugins/bad-parse-method1.js
@@ -1,6 +1,6 @@
 import { BasePlugin } from "v8r";
 
-export default class ValidTestPlugin extends BasePlugin {
+export default class BadParseMethod1TestPlugin extends BasePlugin {
   static name = "v8r-plugin-test-bad-parse-method";
 
   // eslint-disable-next-line no-unused-vars

--- a/testfiles/plugins/bad-parse-method2.js
+++ b/testfiles/plugins/bad-parse-method2.js
@@ -1,0 +1,12 @@
+import { BasePlugin, Document } from "v8r";
+
+export default class BadParseMethod2TestPlugin extends BasePlugin {
+  static name = "v8r-plugin-test-bad-parse-method";
+
+  // eslint-disable-next-line no-unused-vars
+  parseInputFile(contents, fileLocation, parser) {
+    // if we are returning an array
+    // all objects in the array should be a Document
+    return [new Document({}), "foobar"];
+  }
+}


### PR DESCRIPTION
Closes https://github.com/chris48s/v8r/issues/378

Changelog:

- Allow parsing multi-doc yaml
- `parseInputFile()` may now return `Document[]`
- Adds `documentIndex` property to `ValidationResult` type
