### PR TITLE
allow specifying config file location

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -16,12 +16,15 @@ v8r uses [CosmiConfig](https://www.npmjs.com/package/cosmiconfig) to search for 
 - `v8r.config.js`
 - `v8r.config.cjs`
 
-v8r only searches for a config file in the current working directory.
+By default, v8r searches for a config file in the current working directory.
+
+If you want to load a config file from another location, you can invoke v8r with the `V8R_CONFIG_FILE` environment variable. All patterns and relative paths in the config file will be resolved relative to the current working directory rather than the config file location, even if the config file is loaded from somewhere other than the current working directory.
 
 Example yaml config file:
 
 ```yaml title=".v8rrc.yml"
 # - One or more filenames or glob patterns describing local file or files to validate
+#   Patterns are resolved relative to the current working directory.
 # - overridden by passing one or more positional arguments
 patterns: ['*.json']
 
@@ -59,13 +62,14 @@ customCatalog:
           description: Custom Schema  # A description of the schema (optional)
 
           # A Minimatch glob expression for matching up file names with a schema (required)
+          # Expressions are resolved relative to the current working directory.
           fileMatch: ["*.geojson"]
 
           # A URL or local file path for the schema location (required)
           # Unlike the SchemaStore.org format, which has a `url` key,
           # custom catalogs defined in v8r config files have a `location` key
           # which can refer to either a URL or local file.
-          # Relative paths are interpreted as relative to the config file location.
+          # Relative paths are resolved relative to the current working directory.
           location: foo/bar/geojson-schema.json
 
           # A custom parser to use for files matching fileMatch
@@ -80,6 +84,7 @@ plugins:
     # Plugins installed from NPM (or JSR) must be prefixed by "package:"
     - "package:v8r-plugin-emoji-output"
     # Plugins in the project dir must be prefixed by "file:"
+    # Relative paths are resolved relative to the current working directory.
     - "file:./subdir/my-local-plugin.mjs"
 ```
 

--- a/src/bootstrap.spec.js
+++ b/src/bootstrap.spec.js
@@ -160,10 +160,7 @@ describe("getConfig", function () {
     const { config } = await bootstrap(
       ["node", "index.js", "infile.json"],
       undefined,
-      {
-        searchPlaces: ["./testfiles/does-not-exist.json"],
-        cache: false,
-      },
+      { cache: false },
     );
     assert.equal(config.ignoreErrors, false);
     assert.equal(config.cacheTtl, 600);
@@ -176,9 +173,22 @@ describe("getConfig", function () {
     assert(logContainsInfo("No config file found"));
   });
 
+  it("should throw if V8R_CONFIG_FILE does not exist", async function () {
+    process.env.V8R_CONFIG_FILE = "./testfiles/does-not-exist.json";
+    await assert.rejects(
+      bootstrap(["node", "index.js", "infile.json"], undefined, {
+        cache: false,
+      }),
+      {
+        name: "Error",
+        message: "File ./testfiles/does-not-exist.json does not exist.",
+      },
+    );
+  });
+
   it("should read options from config file if available", async function () {
+    process.env.V8R_CONFIG_FILE = "./testfiles/configs/config.json";
     const { config } = await bootstrap(["node", "index.js"], undefined, {
-      searchPlaces: ["./testfiles/configs/config.json"],
       cache: false,
     });
     assert.equal(config.ignoreErrors, true);
@@ -208,6 +218,7 @@ describe("getConfig", function () {
   });
 
   it("should override options from config file with args if specified", async function () {
+    process.env.V8R_CONFIG_FILE = "./testfiles/configs/config.json";
     const { config } = await bootstrap(
       [
         "node",
@@ -219,10 +230,7 @@ describe("getConfig", function () {
         "-vv",
       ],
       undefined,
-      {
-        searchPlaces: ["./testfiles/configs/config.json"],
-        cache: false,
-      },
+      { cache: false },
     );
     assert.deepStrictEqual(config.patterns, ["infile.json"]);
     assert.equal(config.ignoreErrors, true);

--- a/src/bootstrap.spec.js
+++ b/src/bootstrap.spec.js
@@ -1,11 +1,9 @@
 import assert from "assert";
-import path from "path";
 import {
   bootstrap,
   getDocumentFormats,
   getOutputFormats,
   parseArgs,
-  preProcessConfig,
 } from "./bootstrap.js";
 import { loadAllPlugins } from "./plugins.js";
 import { setUp, tearDown, logContainsInfo } from "./test-helpers.js";
@@ -149,57 +147,6 @@ describe("parseArgs", function () {
   });
 });
 
-describe("preProcessConfig", function () {
-  it("passes through absolute paths", function () {
-    const configFile = {
-      config: {
-        customCatalog: { schemas: [{ location: "/foo/bar/schema.json" }] },
-      },
-      filepath: "/home/fred/.v8rrc",
-    };
-    preProcessConfig(configFile);
-    assert.equal(
-      configFile.config.customCatalog.schemas[0].location,
-      "/foo/bar/schema.json",
-    );
-  });
-
-  it("passes through URLs", function () {
-    const configFile = {
-      config: {
-        customCatalog: {
-          schemas: [{ location: "https://example.com/schema.json" }],
-        },
-      },
-      filepath: "/home/fred/.v8rrc",
-    };
-    preProcessConfig(configFile);
-    assert.equal(
-      configFile.config.customCatalog.schemas[0].location,
-      "https://example.com/schema.json",
-    );
-  });
-
-  it("converts relative paths to absolute", function () {
-    const testCases = [
-      ["schema.json", "/home/fred/schema.json"],
-      ["../../schema.json", "/schema.json"],
-      ["foo/bar/schema.json", "/home/fred/foo/bar/schema.json"],
-    ];
-    for (const testCase of testCases) {
-      const configFile = {
-        config: { customCatalog: { schemas: [{ location: testCase[0] }] } },
-        filepath: "/home/fred/.v8rrc",
-      };
-      preProcessConfig(configFile);
-      assert.equal(
-        configFile.config.customCatalog.schemas[0].location,
-        testCase[1],
-      );
-    }
-  });
-});
-
 describe("getConfig", function () {
   beforeEach(function () {
     setUp();
@@ -246,7 +193,7 @@ describe("getConfig", function () {
         {
           name: "custom schema",
           fileMatch: ["valid.json", "invalid.json"],
-          location: path.resolve("./testfiles/schemas/schema.json"),
+          location: "./testfiles/schemas/schema.json",
           parser: "json5",
         },
       ],
@@ -289,7 +236,7 @@ describe("getConfig", function () {
         {
           name: "custom schema",
           fileMatch: ["valid.json", "invalid.json"],
-          location: path.resolve("./testfiles/schemas/schema.json"),
+          location: "./testfiles/schemas/schema.json",
           parser: "json5",
         },
       ],

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -4,6 +4,7 @@ import logger from "./logger.js";
 const origWriteOut = logger.writeOut;
 const origWriteErr = logger.writeErr;
 const testCacheName = process.env.V8R_CACHE_NAME;
+const env = process.env;
 
 function setUp() {
   flatCache.clearCacheById(testCacheName);
@@ -11,6 +12,7 @@ function setUp() {
   logger.resetStderr();
   logger.writeOut = function () {};
   logger.writeErr = function () {};
+  process.env = { ...env };
 }
 
 function tearDown() {
@@ -19,6 +21,7 @@ function tearDown() {
   logger.resetStderr();
   logger.writeOut = origWriteOut;
   logger.writeErr = origWriteErr;
+  process.env = env;
 }
 
 function isString(el) {

--- a/testfiles/configs/config.json
+++ b/testfiles/configs/config.json
@@ -5,7 +5,7 @@
             {
                 "name": "custom schema",
                 "fileMatch": ["valid.json", "invalid.json"],
-                "location": "../schemas/schema.json",
+                "location": "./testfiles/schemas/schema.json",
                 "parser": "json5"
             }
         ]


### PR DESCRIPTION
Closes https://github.com/chris48s/v8r/issues/512

This can't be a command line argument.
Plugins can register command line flags. That means we need to load plugins before we can parse args, which in turn means we have to parse the config file before we can parse args.
So in order to provide this, we make the setting an env var.

**TODO:**

- ~Manual testing for loading config files from arbitrary locations (particularly focussing on relative schema locations)~
- ~Write new unit tests covering this functionality~
- ~Decide if this is a breaking change or not. My gut instinct is it is not, but if it is, batch this up with other breaking changes you want to make into a new major~
