### PR TITLE
migrate to flat-cache 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "chalk": "^5.0.0",
         "cosmiconfig": "^9.0.0",
         "decamelize": "^6.0.0",
-        "flat-cache": "^5.0.0",
+        "flat-cache": "^6.1.4",
         "glob": "^10.1.0",
         "global-agent": "^3.0.0",
         "got": "^13.0.0",
@@ -529,6 +529,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.1.tgz",
+      "integrity": "sha512-kKXeynfORDGPUEEl2PvTExM2zs+IldC6ZD8jPcfvI351MDNtfMlw9V9s4XZXuJNDK2qR5gbEKxRyoYx3quHUVQ==",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -757,6 +765,25 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -803,6 +830,29 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/c8": {
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.2.tgz",
@@ -845,6 +895,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cacheable": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.6.tgz",
+      "integrity": "sha512-RNBnqNhWBtgYNe4mF4395e6260Q9loh6zT2CDFia9LSJor5+vOsvkxhd7GAtg3U4m8i38adn1Q3jiCU1N33/gg==",
+      "dependencies": {
+        "hookified": "^1.5.1",
+        "keyv": "^5.2.1"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -868,6 +927,14 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.2.tgz",
+      "integrity": "sha512-CRPP4Sq5ofbUE8s4FOirFmDgHeKZFRrH/8+WOUNvLJiMIplRMfnMjxmbaDb+zVd7ex0gGAWqMhZHfcL2u6PrNQ==",
+      "dependencies": {
+        "@keyv/serialize": "^1.0.1"
       }
     },
     "node_modules/callsites": {
@@ -1677,21 +1744,19 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.4.tgz",
+      "integrity": "sha512-Km+tVF9BLnxaYqX2R9OKLkwSPvGjDXXlciDC8oBr/nSM4xMCNO8X9s0w5i6lNoE8E/6BEzSJBUF5Bar+TXmKJQ==",
       "dependencies": {
-        "flatted": "^3.3.1",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=18"
+        "cacheable": "^1.8.6",
+        "flatted": "^3.3.2",
+        "hookified": "^1.5.1"
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
     },
     "node_modules/foreground-child": {
       "version": "3.1.1",
@@ -1968,6 +2033,11 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hookified": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.5.1.tgz",
+      "integrity": "sha512-sZQQ5QgNVQUXffNd66qefqOMXA88CXIV0gW8I4bMAJYeu1ZCJsyy7sdchaoHzRyS4o0cXw3krNDXkljZr7uexw=="
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -1990,6 +2060,25 @@
       "engines": {
         "node": ">=10.19.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -4242,6 +4331,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@keyv/serialize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.1.tgz",
+      "integrity": "sha512-kKXeynfORDGPUEEl2PvTExM2zs+IldC6ZD8jPcfvI351MDNtfMlw9V9s4XZXuJNDK2qR5gbEKxRyoYx3quHUVQ==",
+      "requires": {
+        "buffer": "^6.0.3"
+      }
+    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4404,6 +4501,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -4444,6 +4546,15 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "c8": {
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.2.tgz",
@@ -4468,6 +4579,25 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
           "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
+        }
+      }
+    },
+    "cacheable": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.6.tgz",
+      "integrity": "sha512-RNBnqNhWBtgYNe4mF4395e6260Q9loh6zT2CDFia9LSJor5+vOsvkxhd7GAtg3U4m8i38adn1Q3jiCU1N33/gg==",
+      "requires": {
+        "hookified": "^1.5.1",
+        "keyv": "^5.2.1"
+      },
+      "dependencies": {
+        "keyv": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.2.tgz",
+          "integrity": "sha512-CRPP4Sq5ofbUE8s4FOirFmDgHeKZFRrH/8+WOUNvLJiMIplRMfnMjxmbaDb+zVd7ex0gGAWqMhZHfcL2u6PrNQ==",
+          "requires": {
+            "@keyv/serialize": "^1.0.1"
+          }
         }
       }
     },
@@ -5051,18 +5181,19 @@
       "dev": true
     },
     "flat-cache": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.4.tgz",
+      "integrity": "sha512-Km+tVF9BLnxaYqX2R9OKLkwSPvGjDXXlciDC8oBr/nSM4xMCNO8X9s0w5i6lNoE8E/6BEzSJBUF5Bar+TXmKJQ==",
       "requires": {
-        "flatted": "^3.3.1",
-        "keyv": "^4.5.4"
+        "cacheable": "^1.8.6",
+        "flatted": "^3.3.2",
+        "hookified": "^1.5.1"
       }
     },
     "flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
     },
     "foreground-child": {
       "version": "3.1.1",
@@ -5241,6 +5372,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hookified": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.5.1.tgz",
+      "integrity": "sha512-sZQQ5QgNVQUXffNd66qefqOMXA88CXIV0gW8I4bMAJYeu1ZCJsyy7sdchaoHzRyS4o0cXw3krNDXkljZr7uexw=="
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5260,6 +5396,11 @@
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "chalk": "^5.0.0",
     "cosmiconfig": "^9.0.0",
     "decamelize": "^6.0.0",
-    "flat-cache": "^5.0.0",
+    "flat-cache": "^6.1.4",
     "glob": "^10.1.0",
     "global-agent": "^3.0.0",
     "got": "^13.0.0",

--- a/src/ajv.spec.js
+++ b/src/ajv.spec.js
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import flatCache from "flat-cache";
+import { FlatCache } from "flat-cache";
 import { Cache } from "./cache.js";
 import { _ajvFactory } from "./ajv.js";
 import { testCacheName, setUp, tearDown } from "./test-helpers.js";
@@ -9,7 +9,10 @@ describe("_ajvFactory", function () {
     let testCache;
 
     before(function () {
-      testCache = new Cache(flatCache.load(testCacheName), 3000);
+      const ttl = 3000;
+      const cache = new FlatCache({ cacheId: testCacheName, ttl: ttl });
+      cache.load();
+      testCache = new Cache(cache);
     });
 
     beforeEach(function () {

--- a/src/catalogs.spec.js
+++ b/src/catalogs.spec.js
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import flatCache from "flat-cache";
+import { FlatCache } from "flat-cache";
 import { Cache } from "./cache.js";
 import {
   getMatchForFilename,
@@ -122,7 +122,10 @@ describe("getMatchForFilename", function () {
   let testCache;
 
   before(function () {
-    testCache = new Cache(flatCache.load(testCacheName), 3000);
+    const ttl = 3000;
+    const cache = new FlatCache({ cacheId: testCacheName, ttl: ttl });
+    cache.load();
+    testCache = new Cache(cache);
   });
 
   beforeEach(function () {

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -1,4 +1,4 @@
-import flatCache from "flat-cache";
+import { clearCacheById } from "flat-cache";
 import logger from "./logger.js";
 
 const origWriteOut = logger.writeOut;
@@ -7,7 +7,7 @@ const testCacheName = process.env.V8R_CACHE_NAME;
 const env = process.env;
 
 function setUp() {
-  flatCache.clearCacheById(testCacheName);
+  clearCacheById(testCacheName);
   logger.resetStdout();
   logger.resetStderr();
   logger.writeOut = function () {};
@@ -16,7 +16,7 @@ function setUp() {
 }
 
 function tearDown() {
-  flatCache.clearCacheById(testCacheName);
+  clearCacheById(testCacheName);
   logger.resetStdout();
   logger.resetStderr();
   logger.writeOut = origWriteOut;


### PR DESCRIPTION
Migrate from flat-cache 5 to flat-cache 6
Replace home-grown TTL code with native TTL functionality in flat-cache 6