### PR TITLE
clear the cache on init if ttl is 0

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -8,6 +8,9 @@ class Cache {
     this.ttl = this.cache._cache.ttl || 0;
     this.callCounter = {};
     this.callLimit = 10;
+    if (this.ttl === 0) {
+      this.cache.clear();
+    }
   }
 
   limitDepth(url) {


### PR DESCRIPTION
I think this is a regression in 4.2.1

Certainly the current behaviour doesn't match the docs: If you've got entries in the cache and then invoke with `--cache-ttl 0` those cached values will be used.